### PR TITLE
Adjust width height use

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,23 @@ from keplergl import KeplerGl
 
 st.write("This is a kepler.gl map in streamlit")
 
-map_1 = KeplerGl(height=400)
+map_1 = KeplerGl()
 keplergl_static(map_1)
 ```
+By default, the width of the map is determined by the streamlit layout (automatically 
+adjusted when used inside a streamlit column or container). The height is determined by the KeplerGL setting.
+This can be fixed to a specific pixel size via the `width` and `height` parameters of `keplergl_static`, 
+however the size might then not be optimal when viewed on a different device or mobile.
 
-## Options
+```python
+keplergl_static(map_1, height=400, width=500)
+```
 
+To use it within a streamlit column or other object:
+```python
+col1 = st.column(1)
+with col1:
+   keplergl_static(map_1)
 ```
-fig: keplergl.KeplerGl map figure.
-height: Height of result. If height is set on the keplergl.KeplerGl object,
-        that value supersedes the values set with the keyword arguments of this
-        function.
-width: Width of result.
-```
+
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ parent_dir = Path(__file__).resolve().parent
 
 setuptools.setup(
     name="streamlit-keplergl",
-    version="0.1.0",
+    version="0.2.0",
     author="Christoph Rieke",
     author_email="",
     description="Streamlit Component for rendering kepler.gl maps",

--- a/streamlit_keplergl/__init__.py
+++ b/streamlit_keplergl/__init__.py
@@ -1,11 +1,11 @@
-# Load kepler.gl with an empty map
+from typing import Optional
 
 import streamlit.components.v1 as components
 from keplergl import KeplerGl
 
 
 def keplergl_static(
-    fig: KeplerGl, height: int = 400, width: int = 700, scrolling=False
+    fig: KeplerGl, height: Optional[int] = None, width: Optional[int] = None, **kwargs
 ) -> components.html:
     """
     Renders `keplergl.KeplerGl` map figure in a Streamlit app. This method is
@@ -14,22 +14,25 @@ def keplergl_static(
 
     Args:
         fig: `keplergl.KeplerGl` map figure.
-        height: Height of result. If `height` is set on the keplergl.KeplerGl` object,
-                that value supersedes the values set with the keyword arguments of this
-                function.
-        width: Width of result.
+        height: Fixed pixel height of the map, optional. By default determined by the height
+            setting of the KeplerGl.keplergl figure object.
+        width: Fixed pixel width of the map, optional. By default the width of the map adjusts
+            to the streamlit layout option, e.g. also when used inside a column or container etc.
+        kwargs: Add any argument of KeplerGl.save_to_html() (data, config, read_only).
 
     Example:
         ```python
-            >>> map_1 = KeplerGl(height=400)
+            >>> map_1 = KeplerGl()
             >>> keplergl_static(map_1)
         ```
     """
     try:
-        html = fig._repr_html_()
+        html = fig._repr_html_(kwargs)
     except AttributeError:
         raise TypeError("fig argument has to be a keplergl map object of type keplergl.KeplerGl!")
 
+    if height is None:
+        height = fig.height
     return components.html(
-        html, height=(fig.height or height) + 10, width=width, scrolling=scrolling
+        html, height=height + 10, width=width
     )


### PR DESCRIPTION
- Adjusts use of `width` and `height` parameters based on feedback e.g. https://github.com/chrieke/streamlit-keplergl/issues/3 
- Removes forced defaults for `width` & `height` parameters
- `height` parameter now correctly supersedes the keplergl figure object setting
- Adds better explanation and more examples
- Removes st component `scrolling` parameter as had no effect