### PR TITLE
Add visualization parameter explictly, remove kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ st.write("This is a kepler.gl map in streamlit")
 map_1 = KeplerGl()
 keplergl_static(map_1)
 ```
-By default, the width of the map is determined by the streamlit layout (automatically 
-adjusted when used inside a streamlit column or container). The height is determined by the KeplerGL setting.
-This can be fixed to a specific pixel size via the `width` and `height` parameters of `keplergl_static`, 
-however the size might then not be optimal when viewed on a different device or mobile.
 
-```python
-keplergl_static(map_1, height=400, width=500)
-```
+**Parameter:**
+- fig: `keplergl.KeplerGl` map figure.
+- height: Fixed pixel height of the map, optional. By default determined by the height setting of the KeplerGl.
+  keplergl figure object. Setting width and height explcitly might result in non optimal layout on other devices.
+- width: Fixed pixel width of the map, optional. By default the adjusts to the streamlit layout option, e.g. 
+  automatically adjusted to streamlit column or container width.
+- center_map: The bound of the map will be centered on the current map data, default False.
+- read_only: Hide side panel to disable map customization, default False.
+
 
 To use the map widget within a streamlit column or other object:
 ```python

--- a/examples/streamlit-keplergl-example-with-data.py
+++ b/examples/streamlit-keplergl-example-with-data.py
@@ -1,0 +1,22 @@
+import json
+
+import streamlit as st
+from streamlit_keplergl import keplergl_static
+from keplergl import KeplerGl
+import pandas as pd
+
+df = pd.DataFrame(
+    {
+        "City": ["San Francisco", "San Jose"],
+        "Latitude": [37.77, 37.33],
+        "Longitude": [-122.43, -121.89],
+    }
+)
+
+st.dataframe(df.head())
+
+st.write("This is a kepler.gl map in streamlit")
+
+map_1 = KeplerGl(height=400)
+map_1.add_data(data=df, name="cities")
+keplergl_static(map_1, center_map=True)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ parent_dir = Path(__file__).resolve().parent
 
 setuptools.setup(
     name="streamlit-keplergl",
-    version="0.2.0",
+    version="0.3.0",
     author="Christoph Rieke",
     author_email="",
     description="Streamlit Component for rendering kepler.gl maps",

--- a/streamlit_keplergl/__init__.py
+++ b/streamlit_keplergl/__init__.py
@@ -5,12 +5,15 @@ from keplergl import KeplerGl
 
 
 def keplergl_static(
-    fig: KeplerGl, height: Optional[int] = None, width: Optional[int] = None, scrolling=False
+    fig: KeplerGl,
+    height: Optional[int] = None,
+    width: Optional[int] = None,
+    center_map=False,
+    read_only=False,
 ) -> components.html:
     """
-    Renders `keplergl.KeplerGl` map figure in a Streamlit app. This method is
-    a static Streamlit Component, meaning, no information is passed back from
-    KeplerGL on browser interaction.
+    Renders `keplergl.KeplerGl` map figure in a Streamlit app. This method is a static Streamlit Component,
+    thus no information is passed back from KeplerGL on browser interaction.
 
     Args:
         fig: `keplergl.KeplerGl` map figure.
@@ -18,7 +21,8 @@ def keplergl_static(
             setting of the KeplerGl.keplergl figure object.
         width: Fixed pixel width of the map, optional. By default the width of the map adjusts
             to the streamlit layout option, e.g. also when used inside a column or container etc.
-        kwargs: Add any argument of KeplerGl.save_to_html() (data, config, read_only).
+        center_map: if center_map is True, the bound of the map will be updated acoording to the current map data
+        read_only: if read_only is True, hide side panel to disable map customization
 
     Example:
         ```python
@@ -27,12 +31,12 @@ def keplergl_static(
         ```
     """
     try:
-        html = fig._repr_html_()
+        html = fig._repr_html_(center_map=center_map, read_only=read_only)
     except AttributeError:
-        raise TypeError("fig argument has to be a keplergl map object of type keplergl.KeplerGl!")
+        raise TypeError(
+            "fig argument has to be a keplergl map object of type keplergl.KeplerGl!"
+        )
 
     if height is None:
         height = fig.height
-    return components.html(
-        html, height=height + 10, width=width, scrolling=scrolling
-    )
+    return components.html(html, height=height + 10, width=width)

--- a/streamlit_keplergl/__init__.py
+++ b/streamlit_keplergl/__init__.py
@@ -17,12 +17,12 @@ def keplergl_static(
 
     Args:
         fig: `keplergl.KeplerGl` map figure.
-        height: Fixed pixel height of the map, optional. By default determined by the height
-            setting of the KeplerGl.keplergl figure object.
-        width: Fixed pixel width of the map, optional. By default the width of the map adjusts
-            to the streamlit layout option, e.g. also when used inside a column or container etc.
-        center_map: if center_map is True, the bound of the map will be updated acoording to the current map data
-        read_only: if read_only is True, hide side panel to disable map customization
+        height: Fixed pixel height of the map, optional. By default determined by the height setting of the KeplerGl.
+          keplergl figure object. Setting width and height explcitly might result in non optimal layout on other devices.
+        width: Fixed pixel width of the map, optional. By default the adjusts to the streamlit layout option, e.g.
+          automatically adjusted to streamlit column or container width.
+        center_map: The bound of the map will be centered on the current map data, default False.
+        read_only: Hide side panel to disable map customization, default False.
 
     Example:
         ```python


### PR DESCRIPTION
Improves the control of the map visualization by adding `center_map` and `read_only` arguments. Removes `scrolling` argument which was added in https://github.com/chrieke/streamlit-keplergl/pull/8 (not required, https://github.com/chrieke/streamlit-keplergl/issues/7 is fixed by removing the kwargs argument).